### PR TITLE
Fix netstat regex on OSX

### DIFF
--- a/pkg/buyer/internal/net/net_mac.go
+++ b/pkg/buyer/internal/net/net_mac.go
@@ -3,7 +3,7 @@
 package net
 
 var (
-	listeningTCPPortsRegext = `^tcp\s.+\s[\d.]+:(\d+)\s.+$`
+	listeningTCPPortsRegext = `^tcp4\s.+\d+\.(\d+)\s.+LISTEN.*$`
 	netstatCmd              = "netstat"
-	netstatCmdArgs          = []string{"-nlt"}
+	netstatCmdArgs          = []string{"-an"}
 )


### PR DESCRIPTION
On OSX 'netstat -an' yields results like the following:
tcp4       0      0  127.0.0.1.19109        *.*                    LISTEN

- fixed regex on OSX to capture port
- tested on testnet with single buyer