### PR TITLE
Add windows build instructions and save log to the same config file

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -2,7 +2,7 @@
 
 Build using go 1.11 and go modules.
 
-Before building the GUI client, you'll probably need some gtk headers installed:
+Before building the GUI client, you'll probably need some gtk headers installed (see below for Windows instructions):
 
 ```
 # fedora
@@ -19,6 +19,18 @@ $ git clone https://github.com/matheusd/dcr-split-ticket-matcher
 $ cd dcr-split-ticket-matcher
 $ go build ./cmd/...
 ```
+
+## Windows Build
+
+For a Windows build you should use MSYS2. Follow the instructions at the [GTK Website](https://www.gtk.org/download/windows.php) (download and install MSYS2, then install GTK via `pacman`).
+
+On an MSYS2 shell, export the following environment variable:
+
+```
+$ export CGO_LDFLAGS_ALLOW="-Wl,-luuid"
+```
+
+Then proceed using the usual build instructions for a go 1.11+ project.
 
 # Running the Client
 

--- a/pkg/buyer/config-defaults.go
+++ b/pkg/buyer/config-defaults.go
@@ -45,7 +45,7 @@ WalletHost = 127.0.0.1:0
 WalletCertFile =
 
 # Default dir to save session data. Defaults to $HOME/.splitticketbuyer/data
-DataDir = ~/.splitticketbuyer/data
+# DataDir = ~/.splitticketbuyer/data
 
 # Private passphrase of the wallet (use "-" to read from stdin)
 # Use a command such as "promptsecret | splitticketbuyer" for better security


### PR DESCRIPTION
Fix #5 

Logs were actually being stored in `%USERPROFILE%` due to the `DataDir` config option being uncommented in the default config file.