### PR TITLE
Improve split

### DIFF
--- a/pkg/buyer/buyer.go
+++ b/pkg/buyer/buyer.go
@@ -551,7 +551,11 @@ func saveSession(ctx context.Context, session *Session, cfg *Config) error {
 	out("\n")
 	out("====== My Participation Info ======\n")
 	out("Total input amount: %s\n", session.myTotalAmountIn())
-	out("Change amount: %s\n", dcrutil.Amount(session.splitChange.Value))
+	if session.splitChange != nil {
+		out("Change amount: %s\n", dcrutil.Amount(session.splitChange.Value))
+	} else {
+		out("Change amount: [none]\n")
+	}
 	out("Commitment Address: %s\n", session.ticketOutputAddress.EncodeAddress())
 	out("Split Output Address: %s\n", session.splitOutputAddress.EncodeAddress())
 	out("Vote Address: %s\n", cfg.VoteAddress)

--- a/pkg/buyer/matcher-client.go
+++ b/pkg/buyer/matcher-client.go
@@ -150,17 +150,22 @@ func (mc *MatcherClient) generateTicket(ctx context.Context, session *Session, c
 		return err
 	}
 
+	var splitTxChange *pb.TxOut
+	if session.splitChange != nil {
+		splitTxChange = &pb.TxOut{
+			Script: session.splitChange.PkScript,
+			Value:  uint64(session.splitChange.Value),
+		}
+	}
+
 	session.secretNb = splitticket.SecretNumber(matcher.MustRandUint64())
 	session.secretNbHash = session.secretNb.Hash(session.mainchainHash)
 	session.voteAddress = voteAddr
 	session.poolAddress = poolAddr
 
 	req := &pb.GenerateTicketRequest{
-		SessionId: uint32(session.ID),
-		SplitTxChange: &pb.TxOut{
-			Script: session.splitChange.PkScript,
-			Value:  uint64(session.splitChange.Value),
-		},
+		SessionId:         uint32(session.ID),
+		SplitTxChange:     splitTxChange,
 		CommitmentAddress: session.ticketOutputAddress.String(),
 		SplitTxAddress:    session.splitOutputAddress.String(),
 		SecretnbHash:      session.secretNbHash[:],

--- a/pkg/buyer/wallet-client.go
+++ b/pkg/buyer/wallet-client.go
@@ -249,15 +249,15 @@ func (wc *WalletClient) generateSplitTxInputs(ctx context.Context, session *Sess
 		return err
 	}
 
-	foundChangeOut := false
-	for _, out := range tx.TxOut {
-		if bytes.Equal(out.PkScript, splitChangeDest.Script) {
-			foundChangeOut = true
-			session.splitChange.Value = out.Value
+	if resp.ChangeIndex > -1 {
+		out := tx.TxOut[resp.ChangeIndex]
+		if !bytes.Equal(out.PkScript, splitChangeDest.Script) {
+			return errors.Errorf("wallet changed split change pkscript")
 		}
-	}
-	if !foundChangeOut {
-		return errors.Errorf("split change not found on contructed split tx")
+
+		session.splitChange.Value = out.Value
+	} else {
+		session.splitChange = nil
 	}
 
 	session.splitInputs = make([]*wire.TxIn, len(tx.TxIn))

--- a/pkg/daemon/service.go
+++ b/pkg/daemon/service.go
@@ -148,7 +148,9 @@ func (svc *SplitTicketMatcherService) GenerateTicket(ctx context.Context, req *p
 	var commitAddr, splitAddr dcrutil.Address
 	var err error
 
-	splitChange = wire.NewTxOut(int64(req.SplitTxChange.Value), req.SplitTxChange.Script)
+	if req.SplitTxChange != nil {
+		splitChange = wire.NewTxOut(int64(req.SplitTxChange.Value), req.SplitTxChange.Script)
+	}
 
 	if commitAddr, err = dcrutil.DecodeAddress(req.CommitmentAddress); err != nil {
 		return nil, codes.InvalidArgument.Error("error decoding commitment address")

--- a/pkg/matcher/session.go
+++ b/pkg/matcher/session.go
@@ -624,7 +624,11 @@ func (sess *Session) SaveSession(sessionDir string) error {
 		out("\n")
 		out("== Participant %d ==\n", i)
 		out("Amount = %s\n", p.CommitAmount)
-		out("Change = %s\n", dcrutil.Amount(p.splitTxChange.Value))
+		if p.splitTxChange != nil {
+			out("Change = %s\n", dcrutil.Amount(p.splitTxChange.Value))
+		} else {
+			out("Change = [none]\n")
+		}
 		out("Secret Hash = %s\n", p.SecretHash)
 		out("Secret Number = %d\n", p.SecretNb)
 		out("Vote Address = %s\n", p.VoteAddress.EncodeAddress())

--- a/pkg/splitticket/splittx.go
+++ b/pkg/splitticket/splittx.go
@@ -184,7 +184,7 @@ func CheckParticipantInSplit(split *wire.MsgTx, splitAddress dcrutil.Address,
 		}
 	}
 
-	if changeIdx == -1 {
+	if (splitChange != nil) && (changeIdx == -1) {
 		return errors.Errorf("could not find change output in split tx")
 	}
 

--- a/pkg/splitticket/ticket.go
+++ b/pkg/splitticket/ticket.go
@@ -448,20 +448,22 @@ func CheckParticipantInTicket(split, ticket *wire.MsgTx, amount,
 		}
 	}
 
-	found := false
-	for _, out := range split.TxOut {
-		if (out.Value != splitChange.Value) ||
-			(out.Version != splitChange.Version) ||
-			(!bytes.Equal(out.PkScript, splitChange.PkScript)) {
-			continue
+	if splitChange != nil {
+		found := false
+		for _, out := range split.TxOut {
+			if (out.Value != splitChange.Value) ||
+				(out.Version != splitChange.Version) ||
+				(!bytes.Equal(out.PkScript, splitChange.PkScript)) {
+				continue
+			}
+
+			found = true
+			break
 		}
 
-		found = true
-		break
-	}
-
-	if !found {
-		return errors.Errorf("could not find change output in split tx")
+		if !found {
+			return errors.Errorf("could not find change output in split tx")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Part of #15 

While this doesn't change the logic to subtract the split tx fee from the max contribution amount, it does help things by reducing the overcommitted amount to (almost) the bare minimum. 

It also fixes a few bugs in the handling of participants that won't have a change output in the split transaction.