### PR TITLE
Add option to use dcrdata to fetch utxos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/decred/dcrd/rpcclient v1.0.1
 	github.com/decred/dcrd/txscript v1.0.1
 	github.com/decred/dcrd/wire v1.1.0
+	github.com/decred/dcrdata v2.1.3+incompatible
 	github.com/decred/dcrwallet/rpc/walletrpc v0.1.0
 	github.com/decred/dcrwallet/wallet v1.0.0
 	github.com/decred/slog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/dchest/siphash v1.2.0 h1:YWOShuhvg0GqbQpMa60QlCGtEyf7O7HC1Jf0VjdQ60M=
 github.com/dchest/siphash v1.2.0/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/decred/base58 v1.0.0 h1:BVi1FQCThIjZ0ehG+I99NJ51o0xcc9A/fDKhmJxY6+w=
 github.com/decred/base58 v1.0.0/go.mod h1:LLY1p5e3g91byL/UO1eiZaYd+uRoVRarybgcoymu9Ks=
+github.com/decred/dcrd v1.2.0 h1:RWx91j1kMgYmrgZ+JGGaIMDTejroN4Y8pVEzdmPilDs=
 github.com/decred/dcrd/blockchain v1.0.0/go.mod h1:nNMgOz12wlasmEJDCuSuMWYSnjDdmB4l38GKuQ/Yd+8=
 github.com/decred/dcrd/blockchain v1.0.1 h1:7cviDS26sZ9ZyTFka3aC9C/EChXBslmAvse+4nF5d60=
 github.com/decred/dcrd/blockchain v1.0.1/go.mod h1:R/4XnwNOTj5IP8jQIUzrJ8zhr/7EOk09IMODwBamZoI=
@@ -80,6 +81,8 @@ github.com/decred/dcrd/txscript v1.0.1/go.mod h1:FqUX07Y+u3cJ1eIGPoyWbJg+Wk1NTll
 github.com/decred/dcrd/wire v1.0.1/go.mod h1:zpKZnBiN59CrzfXFigwgXmUDVYf34OLbEr8xwAwriHc=
 github.com/decred/dcrd/wire v1.1.0 h1:G+3CugtxNbToUN8RKWqm74yLfzJJ2BKMOr2RgWc4TyY=
 github.com/decred/dcrd/wire v1.1.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
+github.com/decred/dcrdata v2.1.3+incompatible h1:DLzrqgOOgHwrUSbuOVDAUzfQePhCGl9UsjEgZI1D0Kg=
+github.com/decred/dcrdata v2.1.3+incompatible/go.mod h1:9dhUy80j3VCCh0JNYaW3b960hqkxATNq65FxGMYB7mA=
 github.com/decred/dcrwallet/deployments v1.0.0/go.mod h1:0bWER/DAYoGbzkWzbUf6k2agW4YkSyvNLZDhBGThz/4=
 github.com/decred/dcrwallet/errors v1.0.0 h1:XjSILZ2mK5HqWYlhdBpsm+CimFDqDB+hY3tuX0Yh0Jo=
 github.com/decred/dcrwallet/errors v1.0.0/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=

--- a/pkg/buyer/buyer.go
+++ b/pkg/buyer/buyer.go
@@ -258,9 +258,16 @@ func waitForSession(mainCtx context.Context, cfg *Config) sessionWaiterResponse 
 			"error testing wallet funds")}
 	}
 
+	dcrd, err := connectToDecredNode(cfg.networkCfg())
+	if err != nil {
+		setupCancel()
+		return sessionWaiterResponse{nil, nil, nil, errors.Wrap(err,
+			"error connecting to dcrd")}
+	}
+
 	rep.reportStage(setupCtx, StageConnectingToMatcher, nil, cfg)
 	mc, err := ConnectToMatcherService(setupCtx, cfg.MatcherHost, cfg.MatcherCertFile,
-		cfg.networkCfg())
+		dcrd.fetchSplitUtxos)
 	if err != nil {
 		setupCancel()
 		return sessionWaiterResponse{nil, nil, nil, errors.Wrapf(err,
@@ -381,7 +388,8 @@ func buySplitTicketInSession(ctx context.Context, cfg *Config, mc *MatcherClient
 	}
 	rep.reportStage(ctx, StageTicketFunded, session, cfg)
 
-	mc.network.monitorSession(ctx, session)
+	// FIXME: change to use wallet
+	// mc.network.monitorSession(ctx, session)
 
 	rep.reportStage(ctx, StageFundingSplitTx, session, cfg)
 	err = mc.fundSplitTx(ctx, session, cfg)
@@ -401,10 +409,11 @@ func buySplitTicketInSession(ctx context.Context, cfg *Config, mc *MatcherClient
 		return nil
 	}
 
-	err = waitForPublishedTxs(ctx, session, cfg, mc.network)
-	if err != nil {
-		return unreportableError{errors.Wrapf(err, "error waiting for txs to be published")}
-	}
+	// FIXME: change to use wallet
+	// err = waitForPublishedTxs(ctx, session, cfg, mc.network)
+	// if err != nil {
+	// 	return unreportableError{errors.Wrapf(err, "error waiting for txs to be published")}
+	// }
 
 	rep.reportStage(ctx, StageSessionEndedSuccessfully, session, cfg)
 	return nil

--- a/pkg/buyer/config-decrediton.go
+++ b/pkg/buyer/config-decrediton.go
@@ -24,6 +24,7 @@ type decreditonGlobalConfig struct {
 	Network             string                       `json:"network"`
 	DaemonStartAdvanced bool                         `json:"daemon_start_advanced"`
 	RemoteCredentials   *decreditonRemoteCredentials `json:"remote_credentials"`
+	SPVMode             bool                         `json:"spv_mode"`
 }
 type decreditonRemoteCredentials struct {
 	RPCUser     string `json:"rpc_user"`
@@ -265,7 +266,9 @@ func InitConfigFromDecrediton(walletName, poolHost string) error {
 		creds = walletCfg.RemoteCredentials
 	}
 
-	if globalCfg.DaemonStartAdvanced && creds != nil {
+	if globalCfg.SPVMode {
+		dstSection.Key("UtxosFromDcrdata").SetValue("1")
+	} else if globalCfg.DaemonStartAdvanced && creds != nil {
 		dstSection.Key("DcrdHost").SetValue(creds.RPCHost + ":" + creds.RPCPort)
 		dstSection.Key("DcrdUser").SetValue(creds.RPCUser)
 		dstSection.Key("DcrdPass").SetValue(creds.RPCPassword)

--- a/pkg/buyer/config-defaults.go
+++ b/pkg/buyer/config-defaults.go
@@ -18,6 +18,11 @@ PoolAddress =
 # Maximum amount (in DCR) to participate in the split purchase
 MaxAmount = 0.0
 
+# Fetch utxo data from dcrdata instead of using a local dcrd instance. This
+# allows the buyer to use an SPV wallet to participate in a split ticket
+# session.
+UtxosFromDcrdata = 0
+
 # Pool subsidy fee rate (as a percentage). The buyer stops the session if the
 # the service attempt to use a rate higher than this.
 PoolFeeRate = 5.0

--- a/pkg/buyer/consts.go
+++ b/pkg/buyer/consts.go
@@ -19,6 +19,8 @@ const (
 	StageUnknown Stage = iota
 	StageStarting
 	StageConnectingToMatcher
+	StageConnectingToDcrd
+	StageConnectingToDcrdata
 	StageConnectingToWallet
 	StageFindingMatches
 	StageMatchesFound

--- a/pkg/buyer/consts.go
+++ b/pkg/buyer/consts.go
@@ -7,10 +7,6 @@ type reporterCtxKey int
 const (
 	// ReporterCtxKey is the key to use when passing a reporter via context
 	ReporterCtxKey = reporterCtxKey(1)
-
-	// minRequredConfirmations is the minimum number of confirmations the
-	// inputs to the split ticket must have to be usable.
-	minRequredConfirmations = 2
 )
 
 // Following are the various stages the buyer can be in. They may not

--- a/pkg/buyer/dcrd-client.go
+++ b/pkg/buyer/dcrd-client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/matheusd/dcr-split-ticket-matcher/pkg/splitticket"
 	"io/ioutil"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -111,4 +112,8 @@ func (dcrd *decredNetwork) onTxAccepted(txDetails *dcrjson.TxRawResult) {
 
 		dcrd.publishedTicket = tx
 	}
+}
+
+func (dcrd *decredNetwork) fetchSplitUtxos(split *wire.MsgTx) (splitticket.UtxoMap, error) {
+	return splitticket.UtxoMapFromNetwork(dcrd.client, split)
 }

--- a/pkg/buyer/dcrd-client.go
+++ b/pkg/buyer/dcrd-client.go
@@ -1,16 +1,11 @@
 package buyer
 
 import (
-	"context"
-	"encoding/hex"
-	"fmt"
 	"github.com/matheusd/dcr-split-ticket-matcher/pkg/splitticket"
 	"io/ioutil"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/wire"
-	"github.com/pkg/errors"
 
 	"github.com/decred/dcrd/rpcclient"
 )
@@ -47,71 +42,16 @@ func connectToDecredNode(cfg *decredNetworkConfig) (*decredNetwork, error) {
 		Certificates: certs,
 	}
 
-	ntfsHandler := &rpcclient.NotificationHandlers{
-		OnTxAcceptedVerbose: net.onTxAccepted,
-	}
+	ntfsHandler := &rpcclient.NotificationHandlers{}
 
 	client, err := rpcclient.New(connCfg, ntfsHandler)
 	if err != nil {
 		return nil, err
 	}
 
-	err = client.NotifyNewTransactions(true)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error subscribing to tx notifications")
-	}
-
 	net.client = client
 
 	return net, nil
-}
-
-// monitorSession monitors the given session (split and possible tickets) for
-// publishing. Assumes the split and ticket templates have been received and
-// the vote/pool pkscripts of individual participants have also been received.
-func (dcrd *decredNetwork) monitorSession(ctx context.Context, sess *Session) {
-	dcrd.splitHash = sess.splitTx.TxHash()
-
-	dcrd.ticketsHashes = make([]chainhash.Hash, len(sess.participants))
-	for i, p := range sess.participants {
-		dcrd.ticketsHashes[i] = p.ticket.TxHash()
-	}
-}
-
-func (dcrd *decredNetwork) onTxAccepted(txDetails *dcrjson.TxRawResult) {
-	txHash, err := chainhash.NewHashFromStr(txDetails.Txid)
-	if err != nil {
-		// we just ignore this wrong tx hash, as it is not relevant to us.
-		return
-	}
-
-	if txHash.IsEqual(&dcrd.splitHash) {
-		dcrd.publishedSplit = true
-		return
-	}
-
-	for _, th := range dcrd.ticketsHashes {
-		if !txHash.IsEqual(&th) {
-			continue
-		}
-
-		bts, err := hex.DecodeString(txDetails.Hex)
-		if err != nil {
-			// maybe alert here?
-			fmt.Println("err deocding hex")
-			return
-		}
-
-		tx := wire.NewMsgTx()
-		err = tx.FromBytes(bts)
-		if err != nil {
-			// maybe alert here?
-			fmt.Println("err deocding tx")
-			return
-		}
-
-		dcrd.publishedTicket = tx
-	}
 }
 
 func (dcrd *decredNetwork) fetchSplitUtxos(split *wire.MsgTx) (splitticket.UtxoMap, error) {

--- a/pkg/buyer/dcrdata-client.go
+++ b/pkg/buyer/dcrdata-client.go
@@ -1,0 +1,48 @@
+package buyer
+
+import (
+	"encoding/json"
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/wire"
+	dcrdatatypes "github.com/decred/dcrdata/api/types"
+	"github.com/matheusd/dcr-split-ticket-matcher/pkg/splitticket"
+	"github.com/pkg/errors"
+	"net/http"
+	"time"
+)
+
+// utxoProviderForDcrdataURL returns a UtxoMapProvider function that fetches
+// utxo information from the given dcrdata URL.
+func utxoProviderForDcrdataURL(dcrdataURL string) UtxoMapProvider {
+	return func(tx *wire.MsgTx) (splitticket.UtxoMap, error) {
+		return splitticket.UtxoMapFromDcrdata(dcrdataURL, tx)
+	}
+}
+
+// isDcrdataOnline checks whether there is a dcrdata online at the given URL and
+// that it is for the given network. Returns nil if successful or an error.
+func isDcrdataOnline(dcrdataURL string, chainParams *chaincfg.Params) error {
+	url := dcrdataURL + "/api/status"
+	client := http.Client{Timeout: time.Second * 10}
+	urlResp, err := client.Get(url)
+	if err != nil {
+		return errors.Wrap(err, "error during GET /api/status call")
+	}
+
+	defer urlResp.Body.Close()
+	dec := json.NewDecoder(urlResp.Body)
+	resp := new(dcrdatatypes.Status)
+	err = dec.Decode(&resp)
+	if err != nil {
+		return errors.Wrap(err, "error decoding json response")
+	}
+
+	if !resp.Ready {
+		return errors.New("dcrdata instance not ready for use")
+	}
+
+	// TODO: check if network is the same as the one in chainParams (see issue
+	// decred/dcrdata#800)
+
+	return nil
+}

--- a/pkg/buyer/util.go
+++ b/pkg/buyer/util.go
@@ -155,6 +155,12 @@ func (rep *WriterReporter) reportStage(ctx context.Context, stage Stage, session
 	case StageConnectingToWallet:
 		out("Connecting to wallet %s\n", cfg.WalletHost)
 		return
+	case StageConnectingToDcrd:
+		out("Connecting to dcrd %s\n", cfg.DcrdHost)
+		return
+	case StageConnectingToDcrdata:
+		out("Verified dcrdata online %s\n", cfg.DcrdataURL)
+		return
 	}
 
 	// from here on, all stages need a session

--- a/pkg/buyer/wallet-client.go
+++ b/pkg/buyer/wallet-client.go
@@ -234,7 +234,7 @@ func (wc *WalletClient) generateSplitTxInputs(ctx context.Context, session *Sess
 
 	req := &pb.ConstructTransactionRequest{
 		FeePerKb:              0, // whatever is the default wallet fee
-		RequiredConfirmations: minRequredConfirmations,
+		RequiredConfirmations: splitticket.MinimumSplitInputConfirms,
 		SourceAccount:         cfg.SourceAccount,
 		NonChangeOutputs:      outputs,
 		ChangeDestination:     splitChangeDest,
@@ -653,7 +653,7 @@ func (wc *WalletClient) testFunds(ctx context.Context, cfg *Config) error {
 
 	req := &pb.ConstructTransactionRequest{
 		FeePerKb:              0,
-		RequiredConfirmations: minRequredConfirmations,
+		RequiredConfirmations: splitticket.MinimumSplitInputConfirms,
 		SourceAccount:         cfg.SourceAccount,
 		NonChangeOutputs:      outputs,
 		ChangeDestination:     splitChangeDest,

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -424,7 +424,13 @@ func (matcher *Matcher) setParticipantsOutputs(req *setParticipantOutputsRequest
 	}
 
 	var inputAmount dcrutil.Amount
-	for _, utxo := range utxos {
+	for outp, utxo := range utxos {
+		if utxo.Confirmations < splitticket.MinimumSplitInputConfirms {
+			return errors.Errorf("split tx input utxo %s has less confirmations "+
+				"(%d) than the minimum required (%d)", outp.String(),
+				utxo.Confirmations, splitticket.MinimumSplitInputConfirms)
+		}
+
 		inputAmount += utxo.Value
 	}
 

--- a/pkg/splitticket/const.go
+++ b/pkg/splitticket/const.go
@@ -8,4 +8,8 @@ const (
 	// SplitTicketSrvProto is the protocol to use when looking up an SRV
 	// record for the split ticket service
 	SplitTicketSrvProto = "tcp"
+
+	// MinimumSplitInputConfirms is how many confirmations any utxo being used
+	// in the split transaction must have before being allowed in
+	MinimumSplitInputConfirms = 2
 )

--- a/pkg/splitticket/util.go
+++ b/pkg/splitticket/util.go
@@ -42,9 +42,10 @@ func totalOutputAmount(tx *wire.MsgTx) dcrutil.Amount {
 
 // UtxoEntry is an entry of the utxo set of the network
 type UtxoEntry struct {
-	PkScript []byte
-	Value    dcrutil.Amount
-	Version  uint16
+	PkScript      []byte
+	Value         dcrutil.Amount
+	Version       uint16
+	Confirmations int64
 }
 
 // UtxoMap is an auxilary type for the split transaction checks.
@@ -76,7 +77,7 @@ func UtxoMapOutpointsFromNetwork(client *rpcclient.Client, outpoints []*wire.Out
 		}
 
 		if txOut == nil {
-			return nil, errors.Wrapf(err, "outpoint is spent: %s", outp)
+			return nil, errors.Errorf("outpoint is spent/unknown: %s", outp)
 		}
 
 		pkScript, err := hex.DecodeString(txOut.ScriptPubKey.Hex)
@@ -92,9 +93,10 @@ func UtxoMapOutpointsFromNetwork(client *rpcclient.Client, outpoints []*wire.Out
 		}
 
 		res[*outp] = UtxoEntry{
-			PkScript: pkScript,
-			Value:    amount,
-			Version:  uint16(txOut.Version),
+			PkScript:      pkScript,
+			Value:         amount,
+			Version:       uint16(txOut.Version),
+			Confirmations: txOut.Confirmations,
 		}
 	}
 

--- a/pkg/splitticket/util.go
+++ b/pkg/splitticket/util.go
@@ -2,12 +2,17 @@ package splitticket
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/rpcclient"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
+	dcrdatatypes "github.com/decred/dcrdata/api/types"
 	"github.com/pkg/errors"
 )
 
@@ -94,6 +99,68 @@ func UtxoMapOutpointsFromNetwork(client *rpcclient.Client, outpoints []*wire.Out
 	}
 
 	return res, nil
+}
+
+// UtxoMapFromDcrdata queries the dcrdata server for the outpoints of the given
+// transaction and returns an utxo map for use in validation functions.
+func UtxoMapFromDcrdata(dcrdataURL string, tx *wire.MsgTx) (UtxoMap, error) {
+
+	outpoints := make([]*wire.OutPoint, len(tx.TxIn))
+	for i, in := range tx.TxIn {
+		outpoints[i] = &in.PreviousOutPoint
+	}
+	return UtxoMapOutpointsFromDcrdata(dcrdataURL, outpoints)
+}
+
+// UtxoMapOutpointsFromDcrdata queries the dcrdata server for the outpoints of
+// the given transaction and returns an utxo map for use in validation
+// functions.
+func UtxoMapOutpointsFromDcrdata(dcrdataURL string, outpoints []*wire.OutPoint) (UtxoMap, error) {
+
+	// Ideally, this should be a batched call, but dcrdata doesn't currently
+	// have one that will return the pkscript of multiple utxos.
+
+	client := http.Client{Timeout: time.Second * 10}
+	utxos := make(UtxoMap, len(outpoints))
+	respTxOut := new(dcrdatatypes.TxOut)
+
+	for _, outp := range outpoints {
+		url := fmt.Sprintf("%s/api/tx/%s/out/%d", dcrdataURL, outp.Hash.String(),
+			outp.Index)
+
+		urlResp, err := client.Get(url)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error during GET of outpoint %s",
+				outp.String())
+		}
+
+		dec := json.NewDecoder(urlResp.Body)
+		err = dec.Decode(respTxOut)
+		urlResp.Body.Close()
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding json response")
+		}
+
+		amount, err := dcrutil.NewAmount(respTxOut.Value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error converting outpoint %s value "+
+				"(%f) to amount", outp.String(), respTxOut.Value)
+		}
+
+		pkscript, err := hex.DecodeString(respTxOut.PkScript)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error decoding pkscript of outpoint "+
+				"%s from hex", outp.String())
+		}
+
+		utxos[*outp] = UtxoEntry{
+			PkScript: pkscript,
+			Value:    amount,
+			Version:  respTxOut.Version,
+		}
+	}
+
+	return utxos, nil
 }
 
 // FindTxFee finds the total transaction fee paid on the the given transaction


### PR DESCRIPTION
Close #29 

This allows using the buyer with SPV. Changes effected:

- Use the wallet to watch for the published split and ticket transactions instead of watching via dcrd
- Use dcrdata in the buyer to fetch the utxos for other participants
- Detect when dcrd has closed while waiting for a split session