### PR TITLE
matcher: Exec cmd on successful session

### DIFF
--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -69,6 +69,8 @@ type Config struct {
 	KeepAliveTime    time.Duration `long:"keepalivetime" description:"Time duration between server-requested pings to individual clients to see if they are still online"`
 	KeepAliveTimeout time.Duration `long:"keepalivetimeout" description:"Time duration to wait for a reply after a keepalive ping has been sent"`
 
+	SuccessfulSessionCmd string `long:"successfulsessioncmd" description:"An executable to be executed after a successful session is completed. It will receive the ticket hash as first argument."`
+
 	logBackend *slog.Backend
 }
 

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -68,6 +68,10 @@ type Config struct {
 	StakeDiffChangeStopWindow int32
 	PublishTransactions       bool
 	SessionDataDir            string
+
+	// SuccessfulSesssionNtfn is a function run after a successful session is
+	// completed. This is run as a goroutine.
+	SuccessfulSesssionNtfn func(ticketHash chainhash.Hash)
 }
 
 type cancelSessionChanReq struct {
@@ -729,6 +733,10 @@ func (matcher *Matcher) fundSplitTx(req *fundSplitTxRequest, part *SessionPartic
 
 		sess.log.Infof("Session successfully finished as ticket %s",
 			ticket.TxHash())
+
+		if matcher.cfg.SuccessfulSesssionNtfn != nil {
+			go matcher.cfg.SuccessfulSesssionNtfn(ticket.TxHash())
+		}
 		matcher.removeSession(sess, nil)
 	}
 

--- a/samples/dcrstmd.conf
+++ b/samples/dcrstmd.conf
@@ -101,3 +101,8 @@ AllowPublicSession = 0
 # disable the service. This can specify both an address and port, so use (eg)
 # 127.0.0.1:8477 to restrict access to this service for localhost clients.
 # WaitingListWSBindAddr = :8477
+
+# Full path to an executable that will be run after a successful session
+# completes. The first argument to this executable will be the hash of the
+# ticket thas was just completed.
+# SuccessfulSessionCmd = /usr/bin/echo


### PR DESCRIPTION
This allows the daemon to execute a system command after a split session
has been successfully closed. The main purpose of this is to allow VSP
operators to write notification scripts.

close #39