### PR TITLE
matcher: Test for correct stage participation

### DIFF
--- a/pkg/matcher/consts.go
+++ b/pkg/matcher/consts.go
@@ -24,3 +24,33 @@ var (
 	// maximum allowed elapsed time.
 	ErrSessionExpired = errors.New("session expired")
 )
+
+// SessionStage is the stage of a given session
+type SessionStage int
+
+// String returns the string representation of the session stage
+func (ss SessionStage) String() string {
+	switch ss {
+	case StageUnknown:
+		return "unknown"
+	case StageWaitingOutputs:
+		return "waiting outputs"
+	case StageWaitingTicketFunds:
+		return "waiting ticket funds"
+	case StageWaitingSplitFunds:
+		return "waiting split funds"
+	case StageDone:
+		return "done"
+	default:
+		return "invalid"
+	}
+}
+
+// The below constants are for the possible stages a session can be in.
+const (
+	StageUnknown SessionStage = iota
+	StageWaitingOutputs
+	StageWaitingTicketFunds
+	StageWaitingSplitFunds
+	StageDone
+)

--- a/pkg/matcher/session.go
+++ b/pkg/matcher/session.go
@@ -40,6 +40,7 @@ type SessionParticipant struct {
 	SecretHash        splitticket.SecretNumberHash
 	SecretNb          splitticket.SecretNumber
 	SessionToken      []byte
+	CurrentStage      SessionStage
 
 	Session *Session
 	Index   int
@@ -173,6 +174,7 @@ type Session struct {
 	Done            bool
 	Canceled        bool
 	TicketExpiry    uint32
+	CurrentStage    SessionStage
 	log             slog.Logger
 }
 


### PR DESCRIPTION
Close #43 

This adds a CurrentStage property to both Session and
SessionParticipant, such that the matcher can verify whether the request
sent by the buyer corresponds to the correct expected request for the
current stage of the session.

This adds protection against double participation attempt (trying to
send the same request twice) and rogue participation attempts (trying to
send data for the wrong stage of the session).