### PR TITLE
matcher: Improve address validation log msgs

### DIFF
--- a/pkg/daemon/wallet.go
+++ b/pkg/daemon/wallet.go
@@ -115,19 +115,17 @@ func (wallet *WalletClient) SignPoolSplitOutput(split, ticket *wire.MsgTx) ([]by
 // transactions with the provided addresses
 func (wallet *WalletClient) ValidateVoteAddress(voteAddr dcrutil.Address) error {
 
-	voteAddrStr := voteAddr.EncodeAddress()
-
 	resp, err := wallet.client.ValidateAddress(voteAddr)
 	if err != nil {
-		return errors.Wrapf(err, "error validating vote address %s", voteAddrStr)
+		return errors.Wrapf(err, "error validating vote address")
 	}
 
 	if !resp.IsValid {
-		return errors.Errorf("vote address is invalid: %s", voteAddrStr)
+		return errors.Errorf("vote address is invalid")
 	}
 
 	if !resp.IsMine {
-		return errors.Errorf("vote address not controlled by matcher: %s", voteAddrStr)
+		return errors.Errorf("vote address not controlled by matcher wallet")
 	}
 
 	return nil

--- a/pkg/internal/util/addrvalidator.go
+++ b/pkg/internal/util/addrvalidator.go
@@ -82,8 +82,7 @@ func (v *MasterPubPoolAddrValidator) ValidatePoolSubsidyAddress(poolAddr dcrutil
 // the result of a call to EncodeAddress()
 func (v *MasterPubPoolAddrValidator) ValidateByEncodedAddr(addr string) error {
 	if _, has := v.addresses[addr]; !has {
-		return errors.Errorf("pool address %s not found in addresses map",
-			addr)
+		return errors.Errorf("pool address not found in addresses map")
 	}
 
 	return nil

--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -258,15 +258,20 @@ func (matcher *Matcher) notifyWaitingListWatchers() {
 }
 
 func (matcher *Matcher) addParticipant(req *addParticipantRequest) error {
+
 	err := matcher.cfg.VoteAddrValidator.ValidateVoteAddress(req.voteAddress)
 	if err != nil {
-		matcher.log.Errorf("Participant sent invalid vote address: %s", err)
+		origSrc := OriginalSrcFromCtx(req.ctx)
+		matcher.log.Errorf("Participant sent invalid vote address %s from "+
+			"%s: %s", req.voteAddress.EncodeAddress(), origSrc, err)
 		return errors.Wrapf(err, "invalid vote address")
 	}
 
 	err = matcher.cfg.PoolAddrValidator.ValidatePoolSubsidyAddress(req.poolAddress)
 	if err != nil {
-		matcher.log.Errorf("Participant sent invalid pool address: %s", err)
+		origSrc := OriginalSrcFromCtx(req.ctx)
+		matcher.log.Errorf("Participant sent invalid pool address %s from "+
+			"%s: %s", req.poolAddress.EncodeAddress(), origSrc, err)
 		return errors.Wrapf(err, "invalid pool address")
 	}
 

--- a/pkg/poolintegrator/client.go
+++ b/pkg/poolintegrator/client.go
@@ -73,7 +73,7 @@ func (c *Client) ValidatePoolSubsidyAddress(poolAddr dcrutil.Address) error {
 	resp, err := c.client.ValidatePoolSubsidyAddress(ctx, req)
 	if err != nil {
 		return errors.Wrapf(err, "error contacting stakepoold integrator to "+
-			"validate pool subsidy address %s", req.Address)
+			"validate pool subsidy address")
 	}
 
 	if resp.Error != "" {


### PR DESCRIPTION
This slightly improves the log messages for vote address and pool
address validation, so that the original source (address and IP) for the
error is tracked.